### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ A Model Context Protocol (MCP) server that provides access to the Turso-hosted L
 -  Retrieving the schema of a table
 -  Performing SELECT queries
 
+<a href="https://glama.ai/mcp/servers/@nbbaier/mcp-turso">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@nbbaier/mcp-turso/badge" alt="MCP-Turso MCP server" />
+</a>
+
 ## Configuration
 
 ### With Claude Desktop


### PR DESCRIPTION
This PR adds a badge for the [MCP-Turso](https://glama.ai/mcp/servers/@nbbaier/mcp-turso) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@nbbaier/mcp-turso">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@nbbaier/mcp-turso/badge" alt="MCP-Turso MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.